### PR TITLE
Filter out non-objects in list

### DIFF
--- a/data/download.sh
+++ b/data/download.sh
@@ -6,10 +6,13 @@ TEMP_FILE="$(mktemp)"
 WEAPONS_FILE="$SCRIPT_PATH/weapons.json"
 SUMMONS_FILE="$SCRIPT_PATH/summons.json"
 
-JQ_QUERY='map({
+JQ_QUERY='
+map(select(type=="object")) |
+map({
   (._pageName | tostring):
   ._modificationDate | strptime("%Y-%m-%d %H:%M:%S") | mktime
-}) | add'
+}) |
+add'
 
 # Weapons
 printf "Weapons... "


### PR DESCRIPTION
Looks like Cargo API sometimes returns empty arrays in the result, causing the `jq` filter to fail as it expects uniform object:

<details>
<summary>Normal JSON</summary>

```json
[
  {
    "_pageName": "Abu Simbel",
    "_modificationDate": "2023-02-25 17:44:49",
    "_modificationDate__precision": 0
  },
  {
    "_pageName": "Aburaboshi Ramen Flag",
    "_modificationDate": "2022-01-30 19:10:00",
    "_modificationDate__precision": 0
  },
]
```
</details>

<details>
<summary>Sketchy JSON</summary>

```json
[
  [],
  [],
  [],
  {
    "_pageName": "Abu Simbel",
    "_modificationDate": "2023-02-25 17:44:49",
    "_modificationDate__precision": 0
  },
  {
    "_pageName": "Aburaboshi Ramen Flag",
    "_modificationDate": "2022-01-30 19:10:00",
    "_modificationDate__precision": 0
  },
]
```
</details>

This PR just updates the `jq` filter to filter out non-objects beforehand.