### PR TITLE
Stop using deprecated set-output workflow command

### DIFF
--- a/.github/workflows/summons.yaml
+++ b/.github/workflows/summons.yaml
@@ -24,10 +24,10 @@ jobs:
           ./.github/scripts/compare.js data/summons.old.json data/summons.json > list.txt
 
           if [[ "$(cat list.txt)" == "" ]]; then
-            echo "::set-output name=continue::false"
+            echo "continue=false" >> $GITHUB_OUTPUT
             echo "No new page modifications detected." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=continue::true"
+            echo "continue=true" >> $GITHUB_OUTPUT
             echo "The following pages need to be updated:" >> $GITHUB_STEP_SUMMARY
             printf "\`\`\`\n$(cat list.txt)\n\`\`\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/weapons.yaml
+++ b/.github/workflows/weapons.yaml
@@ -24,10 +24,10 @@ jobs:
           ./.github/scripts/compare.js data/weapons.old.json data/weapons.json > list.txt
 
           if [[ "$(cat list.txt)" == "" ]]; then
-            echo "::set-output name=continue::false"
+            echo "continue=false" >> $GITHUB_OUTPUT
             echo "No new page modifications detected." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=continue::true"
+            echo "continue=true" >> $GITHUB_OUTPUT
             echo "The following pages need to be updated:" >> $GITHUB_STEP_SUMMARY
             printf "\`\`\`\n$(cat list.txt)\n\`\`\`" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
Updates workflows to stop using `::set-output` workflow commands as it will break later in June 2023

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/