### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/summons.yaml
+++ b/.github/workflows/summons.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: Check new wiki page modifications
         id: check
@@ -42,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: Setup rclone
         uses: AnimMouse/setup-rclone@50e8a228925a134795c4eb7c455b28e25d3dbee8

--- a/.github/workflows/summons.yaml
+++ b/.github/workflows/summons.yaml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+concurrency:
+  group: sync
 
 jobs:
   check:

--- a/.github/workflows/weapons.yaml
+++ b/.github/workflows/weapons.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: Check new wiki page modifications
         id: check
@@ -42,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: master
 
       - name: Setup rclone
         uses: AnimMouse/setup-rclone@50e8a228925a134795c4eb7c455b28e25d3dbee8

--- a/.github/workflows/weapons.yaml
+++ b/.github/workflows/weapons.yaml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: sync
 
 jobs:
   check:


### PR DESCRIPTION
* Puts both workflows in same concurrency group key, as they cannot run in parallel anyways (since they push something to master).
* Updates both workflows to always checkout master.
  * In the case that both are triggered at the same time (and one is pending), this allows them to not break
  * It also helps with rerunning failed workflows, retry should now just work for older runs (don't need to dispatch new one)